### PR TITLE
Modified the call to ajax.microsoft.com

### DIFF
--- a/ps_wp_denyhost.php
+++ b/ps_wp_denyhost.php
@@ -169,7 +169,7 @@ if ( !class_exists( 'ps_wp_denyhost' ) ) {
 
         function ps_wp_denyhost_script() {
             wp_enqueue_script( 'jquery' );
-            wp_enqueue_script( 'jquery-validate', 'http://ajax.microsoft.com/ajax/jquery.validate/1.6/jquery.validate.min.js', array( 'jquery' ) );
+            wp_enqueue_script( 'jquery-validate', '//ajax.microsoft.com/ajax/jquery.validate/1.6/jquery.validate.min.js', array( 'jquery' ) );
             wp_enqueue_script( 'ps-wp-denyhost-script', $this->url.'?ps_wp_denyhost_javascript', array( 'jquery-validate' ) ); // see end of this file
             wp_localize_script( 'ps-wp-denyhost-script', 'ps_wp_denyhost_lang', array(
                     'required' => __( 'Please enter a number.', $this->localizationDomain ),


### PR DESCRIPTION
With the original call to http://ajax.microsoft.com, if your site loaded over https:// some scripts would fail to load, causing the wp-admin to break. This pull request replaces the call to a protocol agnostic url, which will load over https:// if required.
